### PR TITLE
feat: Add node filtering to query only nodes with target PVCs

### DIFF
--- a/docs/roadmap/ideas.md
+++ b/docs/roadmap/ideas.md
@@ -1,12 +1,8 @@
 ## Future Improvements
 
 ### Tier 1: Quick Wins
-#### 1.1 Node Filtering - Query Only Nodes with Target PVCs
-Current: Query ALL nodes for kubelet stats.
-
-Proposed: Build node set from mounted PVCs, query only those nodes.
-
-Benefit: Could reduce queries, and thus load on API server.
+#### 1.1 Node Filtering - Query Only Nodes with Target PVCs ✓
+Implemented: Controller now discovers target PVCs first, finds pods mounting them, extracts node names, and only queries those specific nodes for kubelet stats.
 
 #### 1.2 Concurrent PVC Patching
 Current: Sequential pvc.Update() calls.

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -62,7 +62,20 @@ func (a *Autoscaler) reconcile(ctx context.Context) {
 		return
 	}
 
-	vsMap, err := a.metricsClient.GetMetrics(ctx)
+	nodeNames, err := a.getNodesWithTargetPVCs(ctx, scList)
+	if err != nil {
+		a.log.Error(err, "getting nodes with target PVCs")
+		return
+	}
+
+	if len(nodeNames) == 0 {
+		a.log.V(1).Info("no target PVCs found, skipping kubelet queries")
+		return
+	}
+
+	a.log.V(1).Info("querying kubelet stats", "nodeCount", len(nodeNames))
+
+	vsMap, err := a.metricsClient.GetMetrics(ctx, nodeNames)
 	if err != nil {
 		a.log.Error(err, "getting volume metrics")
 		return
@@ -121,6 +134,60 @@ func isTargetPVC(pvc *corev1.PersistentVolumeClaim) bool {
 		return false
 	}
 	return pvc.Status.Phase == corev1.ClaimBound
+}
+
+// getNodesWithTargetPVCs returns the set of node names where target PVCs are mounted.
+func (a *Autoscaler) getNodesWithTargetPVCs(ctx context.Context, scList *storagev1.StorageClassList) ([]string, error) {
+	nodeSet := make(map[string]struct{})
+
+	for _, sc := range scList.Items {
+		var pvcList corev1.PersistentVolumeClaimList
+		if err := a.client.List(ctx, &pvcList, client.MatchingFields{
+			indexStorageClassName: sc.Name,
+		}); err != nil {
+			return nil, fmt.Errorf("listing PVCs for StorageClass %s: %w", sc.Name, err)
+		}
+
+		for i := range pvcList.Items {
+			pvc := &pvcList.Items[i]
+			if !isTargetPVC(pvc) {
+				continue
+			}
+
+			var podList corev1.PodList
+			if err := a.client.List(ctx, &podList,
+				client.InNamespace(pvc.Namespace),
+			); err != nil {
+				return nil, fmt.Errorf("listing pods in namespace %s: %w", pvc.Namespace, err)
+			}
+
+			for j := range podList.Items {
+				pod := &podList.Items[j]
+				if pod.Spec.NodeName == "" {
+					continue
+				}
+				if podMountsPVC(pod, pvc.Name) {
+					nodeSet[pod.Spec.NodeName] = struct{}{}
+				}
+			}
+		}
+	}
+
+	nodes := make([]string, 0, len(nodeSet))
+	for node := range nodeSet {
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// podMountsPVC returns true if the pod has a volume that references the named PVC.
+func podMountsPVC(pod *corev1.Pod, pvcName string) bool {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *Autoscaler) resizeIfNeeded(ctx context.Context, pvc *corev1.PersistentVolumeClaim, vs *kubelet.VolumeStats) error {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -130,7 +130,7 @@ type fakeMetricsClient struct {
 	stats map[types.NamespacedName]*kubelet.VolumeStats
 }
 
-func (f *fakeMetricsClient) GetMetrics(_ context.Context) (map[types.NamespacedName]*kubelet.VolumeStats, error) {
+func (f *fakeMetricsClient) GetMetrics(_ context.Context, _ []string) (map[types.NamespacedName]*kubelet.VolumeStats, error) {
 	return f.stats, nil
 }
 
@@ -212,6 +212,119 @@ func TestResizeDecision(t *testing.T) {
 				t.Errorf("newSize = %d (%s), want %d (%s)",
 					newSize, resource.NewQuantity(newSize, resource.BinarySI).String(),
 					tt.expectedSize, resource.NewQuantity(tt.expectedSize, resource.BinarySI).String())
+			}
+		})
+	}
+}
+
+func TestPodMountsPVC(t *testing.T) {
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		pvcName string
+		want    bool
+	}{
+		{
+			"pod mounts the PVC",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "my-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			"my-pvc",
+			true,
+		},
+		{
+			"pod mounts different PVC",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "other-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			"my-pvc",
+			false,
+		},
+		{
+			"pod has no PVC volumes",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+								},
+							},
+						},
+					},
+				},
+			},
+			"my-pvc",
+			false,
+		},
+		{
+			"pod has no volumes",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{},
+				},
+			},
+			"my-pvc",
+			false,
+		},
+		{
+			"pod mounts multiple volumes including target PVC",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+								},
+							},
+						},
+						{
+							Name: "data",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "my-pvc",
+								},
+							},
+						},
+					},
+				},
+			},
+			"my-pvc",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := podMountsPVC(tt.pod, tt.pvcName)
+			if got != tt.want {
+				t.Errorf("podMountsPVC() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -16,5 +16,7 @@ type VolumeStats struct {
 type MetricsClient interface {
 	// GetMetrics returns volume stats keyed by PVC namespace/name.
 	// Only PVCs currently mounted by a pod will have stats.
-	GetMetrics(ctx context.Context) (map[types.NamespacedName]*VolumeStats, error)
+	// If nodeNames is non-empty, only those nodes are queried.
+	// If nodeNames is empty or nil, all nodes are queried.
+	GetMetrics(ctx context.Context, nodeNames []string) (map[types.NamespacedName]*VolumeStats, error)
 }

--- a/internal/kubelet/stats_client.go
+++ b/internal/kubelet/stats_client.go
@@ -53,18 +53,28 @@ func NewStatsClient(clientset kubernetes.Interface) MetricsClient {
 	return &statsClient{clientset: clientset}
 }
 
-func (c *statsClient) GetMetrics(ctx context.Context) (map[types.NamespacedName]*VolumeStats, error) {
-	nodes, err := c.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("listing nodes: %w", err)
+func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (map[types.NamespacedName]*VolumeStats, error) {
+	var nodesToQuery []string
+
+	if len(nodeNames) > 0 {
+		nodesToQuery = nodeNames
+	} else {
+		nodes, err := c.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("listing nodes: %w", err)
+		}
+		nodesToQuery = make([]string, len(nodes.Items))
+		for i, node := range nodes.Items {
+			nodesToQuery[i] = node.Name
+		}
 	}
 
 	result := make(map[types.NamespacedName]*VolumeStats)
 	var mu sync.Mutex
 
 	eg, ctx := errgroup.WithContext(ctx)
-	for _, node := range nodes.Items {
-		nodeName := node.Name
+	for _, nodeName := range nodesToQuery {
+		nodeName := nodeName
 		eg.Go(func() error {
 			nodeStats, err := c.getNodeStats(ctx, nodeName)
 			if err != nil {


### PR DESCRIPTION
Instead of querying all nodes for kubelet stats, the controller now:
1. Discovers target PVCs via StorageClass and annotation filtering
2. Finds pods that mount those PVCs
3. Extracts node names from scheduled pods
4. Queries only those specific nodes for kubelet stats

This reduces kubelet API calls and API server load for clusters where only a subset of nodes run workloads with elastic PVCs.

Closes #1