### PR TITLE
controller: Add rate limiting for resize operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,30 @@ metadata:
 | `elastic-pvc.io/storage-limit` | Yes | - | Maximum size the PVC can grow to (e.g., `500Gi`) |
 | `elastic-pvc.io/threshold` | No | `20%` | Free-space threshold that triggers expansion. Percentage or absolute (e.g., `10Gi`) |
 | `elastic-pvc.io/increase` | No | `50%` | How much to grow each time. Percentage of current capacity or absolute |
+| `elastic-pvc.io/cooldown` | No | `5m` | Minimum interval between resizes for this PVC (e.g., `10m`, `1h`). Overrides global `--resize-cooldown` |
 
 ### Controller Flags
 
 | Flag | Default | Description |
 |---|---|---|
 | `--interval` | `1m` | How often to check PVC usage |
+| `--max-resizes-per-cycle` | `10` | Maximum resize operations per reconciliation cycle |
+| `--resize-cooldown` | `5m` | Minimum interval between resizes for the same PVC |
 | `--metrics-addr` | `:8080` | Prometheus metrics endpoint |
 | `--health-addr` | `:8081` | Health/readiness probe endpoint |
+
+### Rate Limiting
+
+elastic-pvc includes rate limiting to prevent EBS API exhaustion during burst scenarios:
+
+1. **Per-cycle limit**: Only `--max-resizes-per-cycle` PVCs are resized per reconciliation cycle. PVCs with the lowest available space are prioritized.
+
+2. **Per-PVC cooldown**: After a resize, each PVC enters a cooldown period (default: 5 minutes) before it can be resized again. This can be overridden per-PVC with the `elastic-pvc.io/cooldown` annotation.
+
+Rate limiting metrics are exposed at `/metrics`:
+- `elastic_pvc_rate_limited_total{reason="cooldown"}` - resizes skipped due to cooldown
+- `elastic_pvc_rate_limited_total{reason="per_cycle_limit"}` - resizes deferred due to per-cycle limit
+- `elastic_pvc_resizes_total` - successful resize operations
 
 ## Example: Spark on Kubernetes
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,10 +17,12 @@ import (
 )
 
 var cfg struct {
-	metricsAddr   string
-	healthAddr    string
-	watchInterval time.Duration
-	development   bool
+	metricsAddr        string
+	healthAddr         string
+	watchInterval      time.Duration
+	maxResizesPerCycle int
+	resizeCooldown     time.Duration
+	development        bool
 }
 
 var rootCmd = &cobra.Command{
@@ -46,6 +48,8 @@ func init() {
 	fs.StringVar(&cfg.metricsAddr, "metrics-addr", ":8080", "Address for the metrics endpoint")
 	fs.StringVar(&cfg.healthAddr, "health-addr", ":8081", "Address for health/readiness probes")
 	fs.DurationVar(&cfg.watchInterval, "interval", 1*time.Minute, "Interval between resize checks")
+	fs.IntVar(&cfg.maxResizesPerCycle, "max-resizes-per-cycle", 10, "Maximum number of resize operations per reconciliation cycle")
+	fs.DurationVar(&cfg.resizeCooldown, "resize-cooldown", 5*time.Minute, "Minimum interval between resizes for the same PVC")
 	fs.BoolVar(&cfg.development, "development", false, "Enable development logging")
 }
 
@@ -80,6 +84,8 @@ func run() error {
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor("elastic-pvc"),
 		cfg.watchInterval,
+		cfg.maxResizesPerCycle,
+		cfg.resizeCooldown,
 	)
 	if err := mgr.Add(autoscaler); err != nil {
 		return fmt.Errorf("adding autoscaler: %w", err)

--- a/constants.go
+++ b/constants.go
@@ -23,6 +23,14 @@ const (
 	// to detect in-progress resizes. Set automatically by the controller.
 	PrevCapacityAnnotation = AnnotationPrefix + "/prev-capacity"
 
+	// LastResizeAnnotation is an internal annotation tracking when the last resize
+	// was performed. Set automatically by the controller. Value is RFC3339 timestamp.
+	LastResizeAnnotation = AnnotationPrefix + "/last-resize"
+
+	// CooldownAnnotation is an optional PVC annotation to override the default
+	// cooldown period between resizes. Value is a duration (e.g., "10m", "1h").
+	CooldownAnnotation = AnnotationPrefix + "/cooldown"
+
 	// DefaultThreshold is the default free-space threshold (20% of capacity).
 	DefaultThreshold = "20%"
 

--- a/deploy/helm/elastic-pvc/templates/deployment.yaml
+++ b/deploy/helm/elastic-pvc/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --interval={{ .Values.controller.interval }}
+            - --max-resizes-per-cycle={{ .Values.controller.maxResizesPerCycle }}
+            - --resize-cooldown={{ .Values.controller.cooldown }}
             - --metrics-addr=:8080
             - --health-addr=:8081
           ports:

--- a/deploy/helm/elastic-pvc/values.yaml
+++ b/deploy/helm/elastic-pvc/values.yaml
@@ -7,6 +7,8 @@ image:
 
 controller:
   interval: 60s
+  maxResizesPerCycle: 10
+  cooldown: "5m"
   logLevel: info  # info or debug
 
 resources:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,4 +84,6 @@ The controller needs:
 | `elastic-pvc.io/storage-limit` | PVC | Max size (required to be managed) |
 | `elastic-pvc.io/threshold` | PVC | Free-space trigger (default: 20%) |
 | `elastic-pvc.io/increase` | PVC | Growth amount (default: 50%) |
+| `elastic-pvc.io/cooldown` | PVC | Override per-PVC cooldown (e.g., "10m") |
 | `elastic-pvc.io/prev-capacity` | PVC | Internal: tracks in-progress resize |
+| `elastic-pvc.io/last-resize` | PVC | Internal: RFC3339 timestamp of last resize |

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// rateLimitedTotal counts PVC resizes skipped due to rate limiting.
+	rateLimitedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "elastic_pvc_rate_limited_total",
+			Help: "Total PVC resizes skipped due to rate limiting",
+		},
+		[]string{"reason"}, // "cooldown" or "per_cycle_limit"
+	)
+
+	// resizesTotal counts successful resize operations.
+	resizesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "elastic_pvc_resizes_total",
+			Help: "Total successful PVC resize operations",
+		},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(rateLimitedTotal)
+	metrics.Registry.MustRegister(resizesTotal)
+}

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -21,21 +22,34 @@ import (
 
 // Autoscaler periodically checks PVC usage and expands volumes when needed.
 type Autoscaler struct {
-	metricsClient kubelet.MetricsClient
-	client        client.Client
-	recorder      record.EventRecorder
-	interval      time.Duration
-	log           logr.Logger
+	metricsClient      kubelet.MetricsClient
+	client             client.Client
+	recorder           record.EventRecorder
+	interval           time.Duration
+	maxResizesPerCycle int
+	resizeCooldown     time.Duration
+	log                logr.Logger
+}
+
+// resizeCandidate represents a PVC that needs to be resized.
+type resizeCandidate struct {
+	pvc            *corev1.PersistentVolumeClaim
+	stats          *kubelet.VolumeStats
+	newSize        int64
+	currentCapQty  resource.Quantity
+	availableBytes int64
 }
 
 // NewAutoscaler creates an Autoscaler that runs as a controller-runtime Runnable.
-func NewAutoscaler(mc kubelet.MetricsClient, c client.Client, recorder record.EventRecorder, interval time.Duration) *Autoscaler {
+func NewAutoscaler(mc kubelet.MetricsClient, c client.Client, recorder record.EventRecorder, interval time.Duration, maxResizesPerCycle int, resizeCooldown time.Duration) *Autoscaler {
 	return &Autoscaler{
-		metricsClient: mc,
-		client:        c,
-		recorder:      recorder,
-		interval:      interval,
-		log:           ctrl.Log.WithName("autoscaler"),
+		metricsClient:      mc,
+		client:             c,
+		recorder:           recorder,
+		interval:           interval,
+		maxResizesPerCycle: maxResizesPerCycle,
+		resizeCooldown:     resizeCooldown,
+		log:                ctrl.Log.WithName("autoscaler"),
 	}
 }
 
@@ -81,8 +95,43 @@ func (a *Autoscaler) reconcile(ctx context.Context) {
 		return
 	}
 
+	// Collect candidates from all StorageClasses
+	var allCandidates []*resizeCandidate
 	for _, sc := range scList.Items {
-		a.reconcileStorageClass(ctx, &sc, vsMap)
+		candidates := a.collectCandidates(ctx, &sc, vsMap)
+		allCandidates = append(allCandidates, candidates...)
+	}
+
+	if len(allCandidates) == 0 {
+		return
+	}
+
+	// Sort by available bytes ascending (most critical first)
+	sort.Slice(allCandidates, func(i, j int) bool {
+		return allCandidates[i].availableBytes < allCandidates[j].availableBytes
+	})
+
+	// Process up to maxResizesPerCycle candidates
+	resizeCount := 0
+	for _, candidate := range allCandidates {
+		if resizeCount >= a.maxResizesPerCycle {
+			a.log.V(1).Info("per-cycle limit reached, deferring resize",
+				"namespace", candidate.pvc.Namespace,
+				"name", candidate.pvc.Name,
+				"availableBytes", candidate.availableBytes,
+			)
+			rateLimitedTotal.WithLabelValues("per_cycle_limit").Inc()
+			continue
+		}
+
+		if err := a.executeResize(ctx, candidate); err != nil {
+			a.log.Error(err, "resizing PVC",
+				"namespace", candidate.pvc.Namespace,
+				"name", candidate.pvc.Name,
+			)
+			continue
+		}
+		resizeCount++
 	}
 }
 
@@ -97,16 +146,18 @@ func (a *Autoscaler) getEnabledStorageClasses(ctx context.Context) (*storagev1.S
 	return &scList, nil
 }
 
-func (a *Autoscaler) reconcileStorageClass(ctx context.Context, sc *storagev1.StorageClass, vsMap map[types.NamespacedName]*kubelet.VolumeStats) {
+// collectCandidates evaluates all PVCs in the StorageClass and returns resize candidates.
+func (a *Autoscaler) collectCandidates(ctx context.Context, sc *storagev1.StorageClass, vsMap map[types.NamespacedName]*kubelet.VolumeStats) []*resizeCandidate {
 	var pvcList corev1.PersistentVolumeClaimList
 	err := a.client.List(ctx, &pvcList, client.MatchingFields{
 		indexStorageClassName: sc.Name,
 	})
 	if err != nil {
 		a.log.Error(err, "listing PVCs", "storageClass", sc.Name)
-		return
+		return nil
 	}
 
+	var candidates []*resizeCandidate
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
 		if !isTargetPVC(pvc) {
@@ -119,10 +170,146 @@ func (a *Autoscaler) reconcileStorageClass(ctx context.Context, sc *storagev1.St
 			continue // volume not mounted by any pod
 		}
 
-		if err := a.resizeIfNeeded(ctx, pvc, vs); err != nil {
-			a.log.Error(err, "resizing PVC", "namespace", pvc.Namespace, "name", pvc.Name)
+		candidate := a.evaluateCandidate(pvc, vs)
+		if candidate != nil {
+			candidates = append(candidates, candidate)
 		}
 	}
+
+	return candidates
+}
+
+// evaluateCandidate checks if a PVC needs resizing and returns a candidate, or nil if not.
+func (a *Autoscaler) evaluateCandidate(pvc *corev1.PersistentVolumeClaim, vs *kubelet.VolumeStats) *resizeCandidate {
+	log := a.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name)
+
+	// Check cooldown first (cheap check)
+	if a.isInCooldown(pvc) {
+		log.V(1).Info("skipping: in cooldown period")
+		rateLimitedTotal.WithLabelValues("cooldown").Inc()
+		return nil
+	}
+
+	limitQty, err := resource.ParseQuantity(pvc.Annotations[elasticpvc.StorageLimitAnnotation])
+	if err != nil {
+		log.Error(err, "parsing storage-limit")
+		return nil
+	}
+	limitBytes := limitQty.Value()
+
+	currentCap, ok := pvc.Status.Capacity[corev1.ResourceStorage]
+	if !ok || currentCap.Value() == 0 {
+		log.V(1).Info("skipping: capacity not set yet")
+		return nil
+	}
+
+	if currentCap.Value() >= limitBytes {
+		log.V(1).Info("skipping: storage limit reached")
+		return nil
+	}
+
+	// Detect in-progress resize
+	if prevCap, ok := pvc.Annotations[elasticpvc.PrevCapacityAnnotation]; ok {
+		if prevCapBytes, err := strconv.ParseInt(prevCap, 10, 64); err == nil {
+			if prevCapBytes == vs.CapacityBytes {
+				log.V(1).Info("skipping: resize in progress")
+				return nil
+			}
+		}
+	}
+
+	// Parse threshold
+	thresholdStr := annotationOrDefault(pvc, elasticpvc.ThresholdAnnotation, elasticpvc.DefaultThreshold)
+	thresholdBytes, err := resize.ParseValue(thresholdStr, vs.CapacityBytes)
+	if err != nil {
+		log.Error(err, "parsing threshold", "threshold", thresholdStr)
+		return nil
+	}
+
+	if vs.AvailableBytes >= thresholdBytes {
+		return nil // enough free space
+	}
+
+	// Parse increase
+	increaseStr := annotationOrDefault(pvc, elasticpvc.IncreaseAnnotation, elasticpvc.DefaultIncrease)
+	increaseBytes, err := resize.ParseValue(increaseStr, currentCap.Value())
+	if err != nil {
+		log.Error(err, "parsing increase", "increase", increaseStr)
+		return nil
+	}
+
+	newSizeBytes := resize.CalculateNewSize(currentCap.Value(), increaseBytes, limitBytes)
+
+	return &resizeCandidate{
+		pvc:            pvc,
+		stats:          vs,
+		newSize:        newSizeBytes,
+		currentCapQty:  currentCap,
+		availableBytes: vs.AvailableBytes,
+	}
+}
+
+// executeResize performs the actual PVC resize operation.
+func (a *Autoscaler) executeResize(ctx context.Context, candidate *resizeCandidate) error {
+	pvc := candidate.pvc
+	newSize := resource.NewQuantity(candidate.newSize, resource.BinarySI)
+
+	// Patch the PVC
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
+	pvc.Annotations[elasticpvc.PrevCapacityAnnotation] = strconv.FormatInt(candidate.stats.CapacityBytes, 10)
+	pvc.Annotations[elasticpvc.LastResizeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *newSize
+
+	if err := a.client.Update(ctx, pvc); err != nil {
+		return fmt.Errorf("updating PVC: %w", err)
+	}
+
+	a.log.Info("resize triggered",
+		"namespace", pvc.Namespace,
+		"name", pvc.Name,
+		"from", candidate.currentCapQty.String(),
+		"to", newSize.String(),
+		"available", candidate.stats.AvailableBytes,
+	)
+	a.recorder.Eventf(pvc, corev1.EventTypeNormal, "Resized",
+		"PVC resized from %s to %s", candidate.currentCapQty.String(), newSize.String())
+	resizesTotal.Inc()
+
+	return nil
+}
+
+// getCooldown returns the effective cooldown for a PVC, checking the annotation override first.
+func (a *Autoscaler) getCooldown(pvc *corev1.PersistentVolumeClaim) time.Duration {
+	if override, ok := pvc.Annotations[elasticpvc.CooldownAnnotation]; ok {
+		if d, err := time.ParseDuration(override); err == nil {
+			return d
+		}
+		// If parsing fails, fall through to default
+		a.log.V(1).Info("invalid cooldown annotation, using default",
+			"namespace", pvc.Namespace,
+			"name", pvc.Name,
+			"value", override,
+		)
+	}
+	return a.resizeCooldown
+}
+
+// isInCooldown returns true if the PVC was resized too recently.
+func (a *Autoscaler) isInCooldown(pvc *corev1.PersistentVolumeClaim) bool {
+	lastResize, ok := pvc.Annotations[elasticpvc.LastResizeAnnotation]
+	if !ok {
+		return false
+	}
+
+	lastResizeTime, err := time.Parse(time.RFC3339, lastResize)
+	if err != nil {
+		return false
+	}
+
+	cooldown := a.getCooldown(pvc)
+	return time.Since(lastResizeTime) < cooldown
 }
 
 // isTargetPVC returns true if the PVC should be managed by elastic-pvc.
@@ -188,80 +375,6 @@ func podMountsPVC(pod *corev1.Pod, pvcName string) bool {
 		}
 	}
 	return false
-}
-
-func (a *Autoscaler) resizeIfNeeded(ctx context.Context, pvc *corev1.PersistentVolumeClaim, vs *kubelet.VolumeStats) error {
-	log := a.log.WithValues("namespace", pvc.Namespace, "name", pvc.Name)
-
-	limitQty, err := resource.ParseQuantity(pvc.Annotations[elasticpvc.StorageLimitAnnotation])
-	if err != nil {
-		return fmt.Errorf("parsing storage-limit: %w", err)
-	}
-	limitBytes := limitQty.Value()
-
-	currentCap, ok := pvc.Status.Capacity[corev1.ResourceStorage]
-	if !ok || currentCap.Value() == 0 {
-		log.V(1).Info("skipping: capacity not set yet")
-		return nil
-	}
-
-	if currentCap.Value() >= limitBytes {
-		log.V(1).Info("skipping: storage limit reached")
-		return nil
-	}
-
-	// Detect in-progress resize
-	if prevCap, ok := pvc.Annotations[elasticpvc.PrevCapacityAnnotation]; ok {
-		if prevCapBytes, err := strconv.ParseInt(prevCap, 10, 64); err == nil {
-			if prevCapBytes == vs.CapacityBytes {
-				log.V(1).Info("skipping: resize in progress")
-				return nil
-			}
-		}
-	}
-
-	// Parse threshold
-	thresholdStr := annotationOrDefault(pvc, elasticpvc.ThresholdAnnotation, elasticpvc.DefaultThreshold)
-	thresholdBytes, err := resize.ParseValue(thresholdStr, vs.CapacityBytes)
-	if err != nil {
-		return fmt.Errorf("parsing threshold %q: %w", thresholdStr, err)
-	}
-
-	if vs.AvailableBytes >= thresholdBytes {
-		return nil // enough free space
-	}
-
-	// Parse increase
-	increaseStr := annotationOrDefault(pvc, elasticpvc.IncreaseAnnotation, elasticpvc.DefaultIncrease)
-	increaseBytes, err := resize.ParseValue(increaseStr, currentCap.Value())
-	if err != nil {
-		return fmt.Errorf("parsing increase %q: %w", increaseStr, err)
-	}
-
-	newSizeBytes := resize.CalculateNewSize(currentCap.Value(), increaseBytes, limitBytes)
-	newSize := resource.NewQuantity(newSizeBytes, resource.BinarySI)
-
-	// Patch the PVC
-	if pvc.Annotations == nil {
-		pvc.Annotations = make(map[string]string)
-	}
-	pvc.Annotations[elasticpvc.PrevCapacityAnnotation] = strconv.FormatInt(vs.CapacityBytes, 10)
-	pvc.Spec.Resources.Requests[corev1.ResourceStorage] = *newSize
-
-	if err := a.client.Update(ctx, pvc); err != nil {
-		return fmt.Errorf("updating PVC: %w", err)
-	}
-
-	log.Info("resize triggered",
-		"from", currentCap.String(),
-		"to", newSize.String(),
-		"available", vs.AvailableBytes,
-		"threshold", thresholdBytes,
-	)
-	a.recorder.Eventf(pvc, corev1.EventTypeNormal, "Resized",
-		"PVC resized from %s to %s", currentCap.String(), newSize.String())
-
-	return nil
 }
 
 func annotationOrDefault(pvc *corev1.PersistentVolumeClaim, key, defaultVal string) string {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"context"
+	"sort"
 	"testing"
+	"time"
 
 	elasticpvc "elastic-pvc"
 	"elastic-pvc/internal/kubelet"
@@ -327,5 +329,207 @@ func TestPodMountsPVC(t *testing.T) {
 				t.Errorf("podMountsPVC() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsInCooldown(t *testing.T) {
+	defaultCooldown := 5 * time.Minute
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantResult  bool
+	}{
+		{
+			"no last-resize annotation",
+			map[string]string{},
+			false,
+		},
+		{
+			"last-resize was 10 minutes ago (past cooldown)",
+			map[string]string{
+				elasticpvc.LastResizeAnnotation: time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339),
+			},
+			false,
+		},
+		{
+			"last-resize was 2 minutes ago (within cooldown)",
+			map[string]string{
+				elasticpvc.LastResizeAnnotation: time.Now().Add(-2 * time.Minute).UTC().Format(time.RFC3339),
+			},
+			true,
+		},
+		{
+			"last-resize was exactly at cooldown boundary",
+			map[string]string{
+				elasticpvc.LastResizeAnnotation: time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+			},
+			false, // at boundary should not be in cooldown
+		},
+		{
+			"invalid timestamp format",
+			map[string]string{
+				elasticpvc.LastResizeAnnotation: "invalid-timestamp",
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Autoscaler{
+				resizeCooldown: defaultCooldown,
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			got := a.isInCooldown(pvc)
+			if got != tt.wantResult {
+				t.Errorf("isInCooldown() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestGetCooldown(t *testing.T) {
+	defaultCooldown := 5 * time.Minute
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        time.Duration
+	}{
+		{
+			"no cooldown annotation, uses default",
+			map[string]string{},
+			defaultCooldown,
+		},
+		{
+			"valid cooldown annotation override",
+			map[string]string{
+				elasticpvc.CooldownAnnotation: "10m",
+			},
+			10 * time.Minute,
+		},
+		{
+			"cooldown annotation with hours",
+			map[string]string{
+				elasticpvc.CooldownAnnotation: "1h",
+			},
+			1 * time.Hour,
+		},
+		{
+			"cooldown annotation with seconds",
+			map[string]string{
+				elasticpvc.CooldownAnnotation: "30s",
+			},
+			30 * time.Second,
+		},
+		{
+			"invalid cooldown annotation, falls back to default",
+			map[string]string{
+				elasticpvc.CooldownAnnotation: "invalid",
+			},
+			defaultCooldown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &Autoscaler{
+				resizeCooldown: defaultCooldown,
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+			got := a.getCooldown(pvc)
+			if got != tt.want {
+				t.Errorf("getCooldown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCandidatePrioritization(t *testing.T) {
+	// Test that candidates are sorted by availableBytes ascending (most critical first)
+	candidates := []*resizeCandidate{
+		{
+			pvc:            &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-high"}},
+			availableBytes: 100 * 1024 * 1024, // 100MB
+		},
+		{
+			pvc:            &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-critical"}},
+			availableBytes: 10 * 1024 * 1024, // 10MB - most critical
+		},
+		{
+			pvc:            &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-medium"}},
+			availableBytes: 50 * 1024 * 1024, // 50MB
+		},
+	}
+
+	// Sort like reconcile() does
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].availableBytes < candidates[j].availableBytes
+	})
+
+	// Verify order: critical, medium, high
+	expectedOrder := []string{"pvc-critical", "pvc-medium", "pvc-high"}
+	for i, expected := range expectedOrder {
+		if candidates[i].pvc.Name != expected {
+			t.Errorf("position %d: got %s, want %s", i, candidates[i].pvc.Name, expected)
+		}
+	}
+}
+
+func TestPerCycleLimit(t *testing.T) {
+	// Test that only maxResizesPerCycle candidates would be processed
+	maxResizes := 2
+	candidates := []*resizeCandidate{
+		{pvc: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-1"}}, availableBytes: 10},
+		{pvc: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-2"}}, availableBytes: 20},
+		{pvc: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-3"}}, availableBytes: 30},
+		{pvc: &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "pvc-4"}}, availableBytes: 40},
+	}
+
+	// Simulate the per-cycle limit logic from reconcile()
+	var processed []string
+	var deferred []string
+
+	resizeCount := 0
+	for _, candidate := range candidates {
+		if resizeCount >= maxResizes {
+			deferred = append(deferred, candidate.pvc.Name)
+			continue
+		}
+		processed = append(processed, candidate.pvc.Name)
+		resizeCount++
+	}
+
+	if len(processed) != maxResizes {
+		t.Errorf("processed %d candidates, want %d", len(processed), maxResizes)
+	}
+
+	if len(deferred) != len(candidates)-maxResizes {
+		t.Errorf("deferred %d candidates, want %d", len(deferred), len(candidates)-maxResizes)
+	}
+
+	// Verify the right candidates were processed (first two by available bytes)
+	expectedProcessed := []string{"pvc-1", "pvc-2"}
+	for i, expected := range expectedProcessed {
+		if processed[i] != expected {
+			t.Errorf("processed[%d] = %s, want %s", i, processed[i], expected)
+		}
+	}
+
+	// Verify the right candidates were deferred
+	expectedDeferred := []string{"pvc-3", "pvc-4"}
+	for i, expected := range expectedDeferred {
+		if deferred[i] != expected {
+			t.Errorf("deferred[%d] = %s, want %s", i, deferred[i], expected)
+		}
 	}
 }


### PR DESCRIPTION
Adds rate limiting to prevent EBS API exhaustion during burst scenarios:
- Per-cycle limit (--max-resizes-per-cycle): Max N resizes per reconciliation
- Per-PVC cooldown (--resize-cooldown): Minimum interval between resizes
- Prioritization: PVCs with lowest available space are resized first
- Per-PVC cooldown override via elastic-pvc.io/cooldown annotation

Prometheus metrics added for observability:
- elastic_pvc_rate_limited_total{reason="cooldown|per_cycle_limit"}
- elastic_pvc_resizes_total

Relates to: Issue #4
Tests: Added TestIsInCooldown, TestGetCooldown, TestCandidatePrioritization, TestPerCycleLimit