### PR TITLE
kubelet: Return partial results when some nodes fail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.3
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
-	golang.org/x/sync v0.19.0
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
 	k8s.io/client-go v0.35.1
@@ -36,7 +36,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -48,6 +47,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -22,9 +22,18 @@ var (
 			Help: "Total successful PVC resize operations",
 		},
 	)
+
+	// nodeQueryFailuresTotal counts kubelet stats query failures.
+	nodeQueryFailuresTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "elastic_pvc_node_query_failures_total",
+			Help: "Total kubelet stats query failures",
+		},
+	)
 )
 
 func init() {
 	metrics.Registry.MustRegister(rateLimitedTotal)
 	metrics.Registry.MustRegister(resizesTotal)
+	metrics.Registry.MustRegister(nodeQueryFailuresTotal)
 }

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -89,11 +89,22 @@ func (a *Autoscaler) reconcile(ctx context.Context) {
 
 	a.log.V(1).Info("querying kubelet stats", "nodeCount", len(nodeNames))
 
-	vsMap, err := a.metricsClient.GetMetrics(ctx, nodeNames)
+	metricsResult, err := a.metricsClient.GetMetrics(ctx, nodeNames)
 	if err != nil {
 		a.log.Error(err, "getting volume metrics")
 		return
 	}
+
+	if metricsResult.HasFailures() {
+		for _, nodeErr := range metricsResult.FailedNodes {
+			a.log.Info("failed to query node kubelet stats",
+				"node", nodeErr.NodeName,
+				"error", nodeErr.Err.Error())
+		}
+		nodeQueryFailuresTotal.Add(float64(len(metricsResult.FailedNodes)))
+	}
+
+	vsMap := metricsResult.Stats
 
 	// Collect candidates from all StorageClasses
 	var allCandidates []*resizeCandidate

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -129,11 +129,19 @@ func TestAnnotationOrDefault(t *testing.T) {
 
 // fakeMetricsClient implements kubelet.MetricsClient for testing.
 type fakeMetricsClient struct {
-	stats map[types.NamespacedName]*kubelet.VolumeStats
+	stats       map[types.NamespacedName]*kubelet.VolumeStats
+	failedNodes []kubelet.NodeError
+	err         error
 }
 
-func (f *fakeMetricsClient) GetMetrics(_ context.Context, _ []string) (map[types.NamespacedName]*kubelet.VolumeStats, error) {
-	return f.stats, nil
+func (f *fakeMetricsClient) GetMetrics(_ context.Context, _ []string) (*kubelet.MetricsResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &kubelet.MetricsResult{
+		Stats:       f.stats,
+		FailedNodes: f.failedNodes,
+	}, nil
 }
 
 func TestResizeDecision(t *testing.T) {

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -12,11 +12,29 @@ type VolumeStats struct {
 	CapacityBytes  int64
 }
 
+// NodeError records a failure to retrieve stats from a specific node.
+type NodeError struct {
+	NodeName string
+	Err      error
+}
+
+// MetricsResult holds the outcome of a GetMetrics call.
+type MetricsResult struct {
+	Stats       map[types.NamespacedName]*VolumeStats
+	FailedNodes []NodeError
+}
+
+// HasFailures returns true if any nodes failed to respond.
+func (r *MetricsResult) HasFailures() bool {
+	return len(r.FailedNodes) > 0
+}
+
 // MetricsClient retrieves PVC volume usage metrics from the cluster.
 type MetricsClient interface {
 	// GetMetrics returns volume stats keyed by PVC namespace/name.
 	// Only PVCs currently mounted by a pod will have stats.
 	// If nodeNames is non-empty, only those nodes are queried.
 	// If nodeNames is empty or nil, all nodes are queried.
-	GetMetrics(ctx context.Context, nodeNames []string) (map[types.NamespacedName]*VolumeStats, error)
+	// Returns partial results from successful nodes even if some nodes fail.
+	GetMetrics(ctx context.Context, nodeNames []string) (*MetricsResult, error)
 }

--- a/internal/kubelet/stats_client.go
+++ b/internal/kubelet/stats_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -53,7 +52,7 @@ func NewStatsClient(clientset kubernetes.Interface) MetricsClient {
 	return &statsClient{clientset: clientset}
 }
 
-func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (map[types.NamespacedName]*VolumeStats, error) {
+func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (*MetricsResult, error) {
 	var nodesToQuery []string
 
 	if len(nodeNames) > 0 {
@@ -69,29 +68,34 @@ func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (map[t
 		}
 	}
 
-	result := make(map[types.NamespacedName]*VolumeStats)
+	result := &MetricsResult{
+		Stats: make(map[types.NamespacedName]*VolumeStats),
+	}
 	var mu sync.Mutex
+	var wg sync.WaitGroup
 
-	eg, ctx := errgroup.WithContext(ctx)
 	for _, nodeName := range nodesToQuery {
 		nodeName := nodeName
-		eg.Go(func() error {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			nodeStats, err := c.getNodeStats(ctx, nodeName)
-			if err != nil {
-				return fmt.Errorf("node %s: %w", nodeName, err)
-			}
 			mu.Lock()
 			defer mu.Unlock()
-			for k, v := range nodeStats {
-				result[k] = v
+			if err != nil {
+				result.FailedNodes = append(result.FailedNodes, NodeError{
+					NodeName: nodeName,
+					Err:      err,
+				})
+				return
 			}
-			return nil
-		})
+			for k, v := range nodeStats {
+				result.Stats[k] = v
+			}
+		}()
 	}
 
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
+	wg.Wait()
 	return result, nil
 }
 

--- a/internal/kubelet/stats_client_test.go
+++ b/internal/kubelet/stats_client_test.go
@@ -1,10 +1,17 @@
 package kubelet
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 func TestParseStatsSummary(t *testing.T) {
@@ -102,5 +109,225 @@ func TestParseStatsSummary_NilFields(t *testing.T) {
 			}
 			t.Fatal("should not reach here: volume with nil fields should be skipped")
 		}
+	}
+}
+
+// makeStatsResponse generates a kubelet stats/summary JSON response.
+func makeStatsResponse(pvcName, namespace string, available, capacity int64) string {
+	return fmt.Sprintf(`{
+		"pods": [{
+			"podRef": {"name": "test-pod", "namespace": "%s"},
+			"volume": [{
+				"name": "data",
+				"pvcRef": {"name": "%s", "namespace": "%s"},
+				"usedBytes": %d,
+				"capacityBytes": %d,
+				"availableBytes": %d
+			}]
+		}]
+	}`, namespace, pvcName, namespace, capacity-available, capacity, available)
+}
+
+// setupTestServer creates a test server that responds to kubelet stats requests.
+// nodeResponses maps node names to their response (nil value means return error).
+func setupTestServer(t *testing.T, nodeResponses map[string]*string) (*httptest.Server, kubernetes.Interface) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// URL format: /api/v1/nodes/{node}/proxy/stats/summary
+		parts := strings.Split(r.URL.Path, "/")
+		var nodeName string
+		for i, part := range parts {
+			if part == "nodes" && i+1 < len(parts) {
+				nodeName = parts[i+1]
+				break
+			}
+		}
+
+		if nodeName == "" {
+			http.Error(w, "node not found in path", http.StatusBadRequest)
+			return
+		}
+
+		resp, ok := nodeResponses[nodeName]
+		if !ok || resp == nil {
+			http.Error(w, "node unreachable", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(*resp))
+	}))
+
+	config := &rest.Config{
+		Host: server.URL,
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("creating clientset: %v", err)
+	}
+
+	return server, clientset
+}
+
+func TestGetMetrics_SingleNodeFails(t *testing.T) {
+	node1Resp := makeStatsResponse("pvc-1", "default", 5<<30, 10<<30)
+	nodeResponses := map[string]*string{
+		"node-1": &node1Resp,
+		"node-2": nil, // This node will fail
+	}
+
+	server, clientset := setupTestServer(t, nodeResponses)
+	defer server.Close()
+
+	client := NewStatsClient(clientset)
+	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2"})
+
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	// Should have partial results from node-1
+	if len(result.Stats) != 1 {
+		t.Errorf("expected 1 stat, got %d", len(result.Stats))
+	}
+
+	key := types.NamespacedName{Namespace: "default", Name: "pvc-1"}
+	if _, ok := result.Stats[key]; !ok {
+		t.Error("expected stats for pvc-1")
+	}
+
+	// Should have one failed node
+	if len(result.FailedNodes) != 1 {
+		t.Errorf("expected 1 failed node, got %d", len(result.FailedNodes))
+	}
+
+	if result.FailedNodes[0].NodeName != "node-2" {
+		t.Errorf("expected failed node node-2, got %s", result.FailedNodes[0].NodeName)
+	}
+
+	if !result.HasFailures() {
+		t.Error("HasFailures() should return true")
+	}
+}
+
+func TestGetMetrics_AllNodesFail(t *testing.T) {
+	nodeResponses := map[string]*string{
+		"node-1": nil,
+		"node-2": nil,
+		"node-3": nil,
+	}
+
+	server, clientset := setupTestServer(t, nodeResponses)
+	defer server.Close()
+
+	client := NewStatsClient(clientset)
+	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2", "node-3"})
+
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	// Should have empty stats
+	if len(result.Stats) != 0 {
+		t.Errorf("expected 0 stats, got %d", len(result.Stats))
+	}
+
+	// Should have all three nodes as failed
+	if len(result.FailedNodes) != 3 {
+		t.Errorf("expected 3 failed nodes, got %d", len(result.FailedNodes))
+	}
+
+	if !result.HasFailures() {
+		t.Error("HasFailures() should return true")
+	}
+}
+
+func TestGetMetrics_MixedFailures(t *testing.T) {
+	node1Resp := makeStatsResponse("pvc-1", "ns1", 5<<30, 10<<30)
+	node3Resp := makeStatsResponse("pvc-3", "ns3", 3<<30, 8<<30)
+
+	nodeResponses := map[string]*string{
+		"node-1": &node1Resp,
+		"node-2": nil, // fails
+		"node-3": &node3Resp,
+		"node-4": nil, // fails
+	}
+
+	server, clientset := setupTestServer(t, nodeResponses)
+	defer server.Close()
+
+	client := NewStatsClient(clientset)
+	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2", "node-3", "node-4"})
+
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	// Should have stats from 2 successful nodes
+	if len(result.Stats) != 2 {
+		t.Errorf("expected 2 stats, got %d", len(result.Stats))
+	}
+
+	key1 := types.NamespacedName{Namespace: "ns1", Name: "pvc-1"}
+	key3 := types.NamespacedName{Namespace: "ns3", Name: "pvc-3"}
+
+	if _, ok := result.Stats[key1]; !ok {
+		t.Error("expected stats for pvc-1")
+	}
+	if _, ok := result.Stats[key3]; !ok {
+		t.Error("expected stats for pvc-3")
+	}
+
+	// Should have 2 failed nodes
+	if len(result.FailedNodes) != 2 {
+		t.Errorf("expected 2 failed nodes, got %d", len(result.FailedNodes))
+	}
+
+	// Verify the failed nodes (order may vary due to concurrency)
+	failedNodeNames := make(map[string]bool)
+	for _, ne := range result.FailedNodes {
+		failedNodeNames[ne.NodeName] = true
+	}
+
+	if !failedNodeNames["node-2"] {
+		t.Error("expected node-2 in failed nodes")
+	}
+	if !failedNodeNames["node-4"] {
+		t.Error("expected node-4 in failed nodes")
+	}
+}
+
+func TestGetMetrics_AllNodesSucceed(t *testing.T) {
+	node1Resp := makeStatsResponse("pvc-1", "default", 5<<30, 10<<30)
+	node2Resp := makeStatsResponse("pvc-2", "default", 3<<30, 8<<30)
+
+	nodeResponses := map[string]*string{
+		"node-1": &node1Resp,
+		"node-2": &node2Resp,
+	}
+
+	server, clientset := setupTestServer(t, nodeResponses)
+	defer server.Close()
+
+	client := NewStatsClient(clientset)
+	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2"})
+
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	// Should have stats from both nodes
+	if len(result.Stats) != 2 {
+		t.Errorf("expected 2 stats, got %d", len(result.Stats))
+	}
+
+	// Should have no failed nodes
+	if len(result.FailedNodes) != 0 {
+		t.Errorf("expected 0 failed nodes, got %d", len(result.FailedNodes))
+	}
+
+	if result.HasFailures() {
+		t.Error("HasFailures() should return false")
 	}
 }


### PR DESCRIPTION
GetMetrics() previously used errgroup which failed entirely when any single node was unreachable, blocking PVC resizing for the entire cluster.

Now GetMetrics() returns a MetricsResult containing both successful stats and a list of failed nodes. The reconciler logs failures and tracks them via the elastic_pvc_node_query_failures_total metric while continuing to process PVCs on healthy nodes.

Closes #3
Tests: Added TestGetMetrics_{SingleNodeFails,AllNodesFail,MixedFailures,AllNodesSucceed}