### PR TITLE
reconciler: Fix O(N²) node discovery in getNodesWithTargetPVCs

### DIFF
--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -335,9 +335,11 @@ func isTargetPVC(pvc *corev1.PersistentVolumeClaim) bool {
 }
 
 // getNodesWithTargetPVCs returns the set of node names where target PVCs are mounted.
+// It groups target PVCs by namespace, then lists pods once per namespace to find
+// which nodes mount them — avoiding O(PVCs × Pods) API calls.
 func (a *Autoscaler) getNodesWithTargetPVCs(ctx context.Context, scList *storagev1.StorageClassList) ([]string, error) {
-	nodeSet := make(map[string]struct{})
-
+	// Phase 1: collect target PVC names grouped by namespace.
+	nsPVCs := make(map[string]map[string]struct{})
 	for _, sc := range scList.Items {
 		var pvcList corev1.PersistentVolumeClaimList
 		if err := a.client.List(ctx, &pvcList, client.MatchingFields{
@@ -351,23 +353,22 @@ func (a *Autoscaler) getNodesWithTargetPVCs(ctx context.Context, scList *storage
 			if !isTargetPVC(pvc) {
 				continue
 			}
-
-			var podList corev1.PodList
-			if err := a.client.List(ctx, &podList,
-				client.InNamespace(pvc.Namespace),
-			); err != nil {
-				return nil, fmt.Errorf("listing pods in namespace %s: %w", pvc.Namespace, err)
+			if nsPVCs[pvc.Namespace] == nil {
+				nsPVCs[pvc.Namespace] = make(map[string]struct{})
 			}
+			nsPVCs[pvc.Namespace][pvc.Name] = struct{}{}
+		}
+	}
 
-			for j := range podList.Items {
-				pod := &podList.Items[j]
-				if pod.Spec.NodeName == "" {
-					continue
-				}
-				if podMountsPVC(pod, pvc.Name) {
-					nodeSet[pod.Spec.NodeName] = struct{}{}
-				}
-			}
+	// Phase 2: for each namespace, list pods once and find mounting nodes.
+	nodeSet := make(map[string]struct{})
+	for ns, targetPVCs := range nsPVCs {
+		var podList corev1.PodList
+		if err := a.client.List(ctx, &podList, client.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("listing pods in namespace %s: %w", ns, err)
+		}
+		for node := range nodesForPods(podList.Items, targetPVCs) {
+			nodeSet[node] = struct{}{}
 		}
 	}
 
@@ -378,14 +379,25 @@ func (a *Autoscaler) getNodesWithTargetPVCs(ctx context.Context, scList *storage
 	return nodes, nil
 }
 
-// podMountsPVC returns true if the pod has a volume that references the named PVC.
-func podMountsPVC(pod *corev1.Pod, pvcName string) bool {
-	for _, vol := range pod.Spec.Volumes {
-		if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
-			return true
+// nodesForPods returns the set of node names for pods that mount any of the target PVCs.
+// Pods without a NodeName (unscheduled) are skipped.
+func nodesForPods(pods []corev1.Pod, targetPVCs map[string]struct{}) map[string]struct{} {
+	nodes := make(map[string]struct{})
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				if _, ok := targetPVCs[vol.PersistentVolumeClaim.ClaimName]; ok {
+					nodes[pod.Spec.NodeName] = struct{}{}
+					break
+				}
+			}
 		}
 	}
-	return false
+	return nodes
 }
 
 func annotationOrDefault(pvc *corev1.PersistentVolumeClaim, key, defaultVal string) string {

--- a/internal/controller/reconciler_test.go
+++ b/internal/controller/reconciler_test.go
@@ -227,114 +227,136 @@ func TestResizeDecision(t *testing.T) {
 	}
 }
 
-func TestPodMountsPVC(t *testing.T) {
+func TestNodesForPods(t *testing.T) {
 	tests := []struct {
-		name    string
-		pod     *corev1.Pod
-		pvcName string
-		want    bool
+		name       string
+		pods       []corev1.Pod
+		targetPVCs map[string]struct{}
+		wantNodes  map[string]struct{}
 	}{
 		{
-			"pod mounts the PVC",
-			&corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "data",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "my-pvc",
-								},
-							},
+			"pods mounting target PVCs return their nodes",
+			[]corev1.Pod{
+				{Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
 						},
-					},
-				},
+					}},
+				}},
 			},
-			"my-pvc",
-			true,
+			map[string]struct{}{"pvc-a": {}},
+			map[string]struct{}{"node-1": {}},
 		},
 		{
-			"pod mounts different PVC",
-			&corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: "data",
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "other-pvc",
-								},
-							},
+			"pods mounting non-target PVCs are excluded",
+			[]corev1.Pod{
+				{Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "other-pvc"},
 						},
-					},
-				},
+					}},
+				}},
 			},
-			"my-pvc",
-			false,
+			map[string]struct{}{"pvc-a": {}},
+			map[string]struct{}{},
 		},
 		{
-			"pod has no PVC volumes",
-			&corev1.Pod{
-				Spec: corev1.PodSpec{
+			"unscheduled pods (no NodeName) are skipped",
+			[]corev1.Pod{
+				{Spec: corev1.PodSpec{
+					NodeName: "",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
+						},
+					}},
+				}},
+			},
+			map[string]struct{}{"pvc-a": {}},
+			map[string]struct{}{},
+		},
+		{
+			"multiple pods on same node are deduplicated",
+			[]corev1.Pod{
+				{Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
+						},
+					}},
+				}},
+				{Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-b"},
+						},
+					}},
+				}},
+			},
+			map[string]struct{}{"pvc-a": {}, "pvc-b": {}},
+			map[string]struct{}{"node-1": {}},
+		},
+		{
+			"empty inputs return empty result",
+			nil,
+			map[string]struct{}{},
+			map[string]struct{}{},
+		},
+		{
+			"pod mounting multiple PVCs, one target",
+			[]corev1.Pod{
+				{Spec: corev1.PodSpec{
+					NodeName: "node-2",
 					Volumes: []corev1.Volume{
 						{
 							Name: "config",
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
+									LocalObjectReference: corev1.LocalObjectReference{Name: "cfg"},
 								},
 							},
 						},
-					},
-				},
-			},
-			"my-pvc",
-			false,
-		},
-		{
-			"pod has no volumes",
-			&corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{},
-				},
-			},
-			"my-pvc",
-			false,
-		},
-		{
-			"pod mounts multiple volumes including target PVC",
-			&corev1.Pod{
-				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
 						{
-							Name: "config",
+							Name: "other",
 							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: "my-config"},
-								},
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "non-target"},
 							},
 						},
 						{
 							Name: "data",
 							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: "my-pvc",
-								},
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
 							},
 						},
 					},
-				},
+				}},
 			},
-			"my-pvc",
-			true,
+			map[string]struct{}{"pvc-a": {}},
+			map[string]struct{}{"node-2": {}},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := podMountsPVC(tt.pod, tt.pvcName)
-			if got != tt.want {
-				t.Errorf("podMountsPVC() = %v, want %v", got, tt.want)
+			got := nodesForPods(tt.pods, tt.targetPVCs)
+			if len(got) != len(tt.wantNodes) {
+				t.Fatalf("nodesForPods() returned %d nodes, want %d", len(got), len(tt.wantNodes))
+			}
+			for node := range tt.wantNodes {
+				if _, ok := got[node]; !ok {
+					t.Errorf("nodesForPods() missing expected node %q", node)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
getNodesWithTargetPVCs listed all pods in a namespace for each PVC, creating O(PVCs × Pods) API calls per reconciliation cycle. In a namespace with many executor pods each mounting a PVC, this scales quadratically.

Restructure the function into two phases: first collect target PVC names grouped by namespace, then list pods once per namespace and match against the PVC name set. This reduces complexity to O(PVCs + Pods).

Replace the per-PVC podMountsPVC helper with a pure nodesForPods function that takes a pod slice and a target-PVC set, enabling straightforward unit testing without a k8s client.

Closes: #16
Tests: Replace TestPodMountsPVC with TestNodesForPods covering target mounts, non-target exclusion, unscheduled pods, same-node dedup, empty inputs, and multi-volume pods.