### PR TITLE
kubelet: Add bounded concurrency and per-node timeouts for stats collection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,12 +17,14 @@ import (
 )
 
 var cfg struct {
-	metricsAddr        string
-	healthAddr         string
-	watchInterval      time.Duration
-	maxResizesPerCycle int
-	resizeCooldown     time.Duration
-	development        bool
+	metricsAddr               string
+	healthAddr                string
+	watchInterval             time.Duration
+	maxResizesPerCycle        int
+	resizeCooldown            time.Duration
+	maxConcurrentNodeQueries  int
+	nodeQueryTimeout          time.Duration
+	development               bool
 }
 
 var rootCmd = &cobra.Command{
@@ -50,6 +52,8 @@ func init() {
 	fs.DurationVar(&cfg.watchInterval, "interval", 1*time.Minute, "Interval between resize checks")
 	fs.IntVar(&cfg.maxResizesPerCycle, "max-resizes-per-cycle", 10, "Maximum number of resize operations per reconciliation cycle")
 	fs.DurationVar(&cfg.resizeCooldown, "resize-cooldown", 5*time.Minute, "Minimum interval between resizes for the same PVC")
+	fs.IntVar(&cfg.maxConcurrentNodeQueries, "max-concurrent-node-queries", 10, "Maximum number of parallel kubelet stats requests")
+	fs.DurationVar(&cfg.nodeQueryTimeout, "node-query-timeout", 10*time.Second, "Per-node kubelet stats query timeout")
 	fs.BoolVar(&cfg.development, "development", false, "Enable development logging")
 }
 
@@ -80,7 +84,7 @@ func run() error {
 	}
 
 	autoscaler := controller.NewAutoscaler(
-		kubelet.NewStatsClient(clientset),
+		kubelet.NewStatsClient(clientset, cfg.maxConcurrentNodeQueries, cfg.nodeQueryTimeout),
 		mgr.GetClient(),
 		mgr.GetEventRecorderFor("elastic-pvc"),
 		cfg.watchInterval,

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -30,10 +30,20 @@ var (
 			Help: "Total kubelet stats query failures",
 		},
 	)
+
+	// reconcileDurationSeconds observes how long each reconciliation cycle takes.
+	reconcileDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "elastic_pvc_reconcile_duration_seconds",
+			Help:    "Duration of each reconciliation cycle in seconds",
+			Buckets: []float64{0.5, 1, 2, 5, 10, 30, 60, 120},
+		},
+	)
 )
 
 func init() {
 	metrics.Registry.MustRegister(rateLimitedTotal)
 	metrics.Registry.MustRegister(resizesTotal)
 	metrics.Registry.MustRegister(nodeQueryFailuresTotal)
+	metrics.Registry.MustRegister(reconcileDurationSeconds)
 }

--- a/internal/controller/reconciler.go
+++ b/internal/controller/reconciler.go
@@ -64,9 +64,21 @@ func (a *Autoscaler) Start(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			a.reconcile(ctx)
+			a.runReconcile(ctx)
 		}
 	}
+}
+
+// runReconcile wraps reconcile with a cycle-level timeout and duration observation.
+// The timeout is 80% of the configured interval to prevent cycles from overlapping.
+func (a *Autoscaler) runReconcile(ctx context.Context) {
+	cycleTimeout := time.Duration(float64(a.interval) * 0.8)
+	cycleCtx, cancel := context.WithTimeout(ctx, cycleTimeout)
+	defer cancel()
+
+	start := time.Now()
+	a.reconcile(cycleCtx)
+	reconcileDurationSeconds.Observe(time.Since(start).Seconds())
 }
 
 func (a *Autoscaler) reconcile(ctx context.Context) {

--- a/internal/kubelet/stats_client.go
+++ b/internal/kubelet/stats_client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,12 +45,20 @@ type pvcReference struct {
 // statsClient queries the kubelet /stats/summary endpoint on each node
 // to collect PVC volume usage data.
 type statsClient struct {
-	clientset kubernetes.Interface
+	clientset      kubernetes.Interface
+	maxConcurrent  int
+	nodeTimeout    time.Duration
 }
 
 // NewStatsClient creates a MetricsClient that reads volume stats from kubelet.
-func NewStatsClient(clientset kubernetes.Interface) MetricsClient {
-	return &statsClient{clientset: clientset}
+// maxConcurrent limits the number of parallel kubelet queries.
+// nodeTimeout is the per-node query deadline.
+func NewStatsClient(clientset kubernetes.Interface, maxConcurrent int, nodeTimeout time.Duration) MetricsClient {
+	return &statsClient{
+		clientset:     clientset,
+		maxConcurrent: maxConcurrent,
+		nodeTimeout:   nodeTimeout,
+	}
 }
 
 func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (*MetricsResult, error) {
@@ -74,12 +83,26 @@ func (c *statsClient) GetMetrics(ctx context.Context, nodeNames []string) (*Metr
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
+	sem := make(chan struct{}, c.maxConcurrent)
+
+dispatch:
 	for _, nodeName := range nodesToQuery {
+		select {
+		case <-ctx.Done():
+			break dispatch
+		case sem <- struct{}{}:
+		}
+
 		nodeName := nodeName
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			nodeStats, err := c.getNodeStats(ctx, nodeName)
+			defer func() { <-sem }()
+
+			nodeCtx, cancel := context.WithTimeout(ctx, c.nodeTimeout)
+			defer cancel()
+
+			nodeStats, err := c.getNodeStats(nodeCtx, nodeName)
 			mu.Lock()
 			defer mu.Unlock()
 			if err != nil {

--- a/internal/kubelet/stats_client_test.go
+++ b/internal/kubelet/stats_client_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -180,7 +182,7 @@ func TestGetMetrics_SingleNodeFails(t *testing.T) {
 	server, clientset := setupTestServer(t, nodeResponses)
 	defer server.Close()
 
-	client := NewStatsClient(clientset)
+	client := NewStatsClient(clientset, 10, 30*time.Second)
 	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2"})
 
 	if err != nil {
@@ -221,7 +223,7 @@ func TestGetMetrics_AllNodesFail(t *testing.T) {
 	server, clientset := setupTestServer(t, nodeResponses)
 	defer server.Close()
 
-	client := NewStatsClient(clientset)
+	client := NewStatsClient(clientset, 10, 30*time.Second)
 	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2", "node-3"})
 
 	if err != nil {
@@ -257,7 +259,7 @@ func TestGetMetrics_MixedFailures(t *testing.T) {
 	server, clientset := setupTestServer(t, nodeResponses)
 	defer server.Close()
 
-	client := NewStatsClient(clientset)
+	client := NewStatsClient(clientset, 10, 30*time.Second)
 	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2", "node-3", "node-4"})
 
 	if err != nil {
@@ -310,7 +312,7 @@ func TestGetMetrics_AllNodesSucceed(t *testing.T) {
 	server, clientset := setupTestServer(t, nodeResponses)
 	defer server.Close()
 
-	client := NewStatsClient(clientset)
+	client := NewStatsClient(clientset, 10, 30*time.Second)
 	result, err := client.GetMetrics(context.Background(), []string{"node-1", "node-2"})
 
 	if err != nil {
@@ -329,5 +331,175 @@ func TestGetMetrics_AllNodesSucceed(t *testing.T) {
 
 	if result.HasFailures() {
 		t.Error("HasFailures() should return false")
+	}
+}
+
+// setupDelayServer creates a test server that tracks concurrent in-flight requests
+// and optionally delays responses. handlerDelay is applied per request. The returned
+// atomic int64 tracks the peak concurrent requests observed.
+func setupDelayServer(t *testing.T, nodeNames []string, handlerDelay time.Duration) (*httptest.Server, kubernetes.Interface, *atomic.Int64) {
+	t.Helper()
+
+	var inflight atomic.Int64
+	var peak atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cur := inflight.Add(1)
+		defer inflight.Add(-1)
+
+		for {
+			old := peak.Load()
+			if cur <= old || peak.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+
+		time.Sleep(handlerDelay)
+
+		parts := strings.Split(r.URL.Path, "/")
+		var nodeName string
+		for i, part := range parts {
+			if part == "nodes" && i+1 < len(parts) {
+				nodeName = parts[i+1]
+				break
+			}
+		}
+
+		resp := makeStatsResponse("pvc-"+nodeName, "default", 5<<30, 10<<30)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp))
+	}))
+
+	config := &rest.Config{Host: server.URL}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("creating clientset: %v", err)
+	}
+
+	return server, clientset, &peak
+}
+
+func TestGetMetrics_BoundedConcurrency(t *testing.T) {
+	const maxConcurrent = 3
+	const nodeCount = 20
+
+	nodeNames := make([]string, nodeCount)
+	for i := range nodeNames {
+		nodeNames[i] = fmt.Sprintf("node-%d", i)
+	}
+
+	server, clientset, peak := setupDelayServer(t, nodeNames, 50*time.Millisecond)
+	defer server.Close()
+
+	client := NewStatsClient(clientset, maxConcurrent, 30*time.Second)
+	result, err := client.GetMetrics(context.Background(), nodeNames)
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	if len(result.Stats) != nodeCount {
+		t.Errorf("expected %d stats, got %d", nodeCount, len(result.Stats))
+	}
+
+	if peak.Load() > int64(maxConcurrent) {
+		t.Errorf("peak concurrent requests = %d, want <= %d", peak.Load(), maxConcurrent)
+	}
+}
+
+func TestGetMetrics_NodeTimeout(t *testing.T) {
+	fastResp := makeStatsResponse("pvc-fast", "default", 5<<30, 10<<30)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+		var nodeName string
+		for i, part := range parts {
+			if part == "nodes" && i+1 < len(parts) {
+				nodeName = parts[i+1]
+				break
+			}
+		}
+
+		if nodeName == "slow-node" {
+			// Sleep longer than the node timeout
+			time.Sleep(5 * time.Second)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(fastResp))
+	}))
+	defer server.Close()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("creating clientset: %v", err)
+	}
+
+	nodeTimeout := 200 * time.Millisecond
+	client := NewStatsClient(clientset, 10, nodeTimeout)
+
+	start := time.Now()
+	result, err := client.GetMetrics(context.Background(), []string{"fast-node", "slow-node"})
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
+	}
+
+	// fast-node should succeed
+	key := types.NamespacedName{Namespace: "default", Name: "pvc-fast"}
+	if _, ok := result.Stats[key]; !ok {
+		t.Error("expected stats for fast-node's pvc-fast")
+	}
+
+	// slow-node should fail with timeout
+	if len(result.FailedNodes) != 1 {
+		t.Fatalf("expected 1 failed node, got %d", len(result.FailedNodes))
+	}
+	if result.FailedNodes[0].NodeName != "slow-node" {
+		t.Errorf("expected slow-node to fail, got %s", result.FailedNodes[0].NodeName)
+	}
+
+	// Total time should be close to nodeTimeout, not 5s
+	if elapsed > 2*time.Second {
+		t.Errorf("GetMetrics took %v, expected close to %v (not slow-node's 5s delay)", elapsed, nodeTimeout)
+	}
+}
+
+func TestGetMetrics_ParentContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// All nodes are slow
+		time.Sleep(10 * time.Second)
+		resp := makeStatsResponse("pvc-x", "default", 5<<30, 10<<30)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	clientset, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("creating clientset: %v", err)
+	}
+
+	client := NewStatsClient(clientset, 10, 30*time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after 200ms
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err = client.GetMetrics(ctx, []string{"node-1", "node-2", "node-3"})
+	elapsed := time.Since(start)
+
+	// Should return promptly (within ~1s, not 30s node timeout or 10s server delay)
+	if elapsed > 2*time.Second {
+		t.Errorf("GetMetrics took %v after context cancellation, expected prompt return", elapsed)
+	}
+
+	// err should be nil (partial results returned), but all nodes should be failed
+	if err != nil {
+		t.Fatalf("GetMetrics returned error: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #18.

## Problem

On large Spark on EKS clusters (500+ nodes), the kubelet stats collection in GetMetrics has three scaling issues:

1. Unbounded goroutines: Spawns one goroutine per node with no concurrency limit. On a 500-node cluster, this means 500 simultaneous API server proxy requests — causing throttling or OOM.
2. No per-node timeout: Uses the parent context with no deadline. A single slow/unresponsive kubelet hangs the entire reconciliation cycle. On large clusters, the probability of at least one slow kubelet per cycle approaches 100%.
3. No reconciliation cycle timeout: If reconcile() takes longer than the ticker interval, the next tick fires immediately. There is no guard to prevent runaway reconciliation from cascading.

## Proposed Solution

**Bounded concurrency**: add a buffered-channel semaphore to GetMetrics to limit concurrent kubelet queries. Configurable via --max-concurrent-node-queries (default: 10).

**Per-node timeout**: derive a child context with timeout for each node query. Configurable via --node-query-timeout (default: 10s). A slow kubelet times out individually without blocking others.

**Reconciliation cycle timeout**: Add a runReconcile wrapper that creates a deadline context at 80% of --interval. All downstream calls inherit the deadline.

**Reconcile duration metric**: Add elastic_pvc_reconcile_duration_seconds histogram for alerting on slow cycles.